### PR TITLE
Перевод Markdown ячеек в chap19

### DIFF
--- a/chapters/chap19.ipynb
+++ b/chapters/chap19.ipynb
@@ -5,9 +5,7 @@
    "id": "1331faa1",
    "metadata": {},
    "source": [
-    "You can order print and ebook versions of *Think Python 3e* from\n",
-    "[Bookshop.org](https://bookshop.org/a/98697/9781098155438) and\n",
-    "[Amazon](https://www.amazon.com/_/dp/1098155432?smid=ATVPDKIKX0DER&_encoding=UTF8&tag=oreilly20-20&_encoding=UTF8&tag=greenteapre01-20&linkCode=ur2&linkId=e2a529f94920295d27ec8a06e757dc7c&camp=1789&creative=9325)."
+    "Вы можете заказать печатную и электронную версии *Think Python 3e* на [Bookshop.org](https://bookshop.org/a/98697/9781098155438) и [Amazon](https://www.amazon.com/_/dp/1098155432?smid=ATVPDKIKX0DER&_encoding=UTF8&tag=oreilly20-20&_encoding=UTF8&tag=greenteapre01-20&linkCode=ur2&linkId=e2a529f94920295d27ec8a06e757dc7c&camp=1789&creative=9325).\n"
    ]
   },
   {
@@ -15,7 +13,7 @@
    "id": "171aca73",
    "metadata": {},
    "source": [
-    "# Final thoughts"
+    "# Заключительные мысли\n"
    ]
   },
   {
@@ -23,19 +21,19 @@
    "id": "4d551c99",
    "metadata": {},
    "source": [
-    "Learning to program is not easy, but if you made it this far, you are off to a good start.\n",
-    "Now I have some suggestions for ways you can keep learning and apply what you have learned.\n",
+    "Учиться программировать непросто, но если вы дошли до этого места, вы уже неплохо начали.\n",
+    "Теперь у меня есть несколько предложений, как вы можете продолжать учиться и применять полученные знания.\n",
     "\n",
-    "This book is meant to be a general introduction to programming, so we have not focused on specific applications.\n",
-    "Depending on your interests, there are any number of areas where you can apply your new skills.\n",
+    "Эта книга предназначена как общее введение в программирование, поэтому мы не сосредотачивались на конкретных приложениях.\n",
+    "В зависимости от ваших интересов есть множество областей, где вы можете применить свои новые навыки.\n",
     "\n",
-    "If you are interested in Data Science, there are three books of mine you might like:\n",
+    "Если вам интересна Data Science, вот три моих книги, которые вам могут понравиться:\n",
     "\n",
     "* *Think Stats: Exploratory Data Analysis*, O'Reilly Media, 2014.\n",
     "\n",
     "* *Think Bayes: Bayesian Statistics in Python*, O'Reilly Media, 2021.\n",
     "\n",
-    "* *Think DSP: Digital Signal Processing in Python*, O'Reilly Media, 2016."
+    "* *Think DSP: Digital Signal Processing in Python*, O'Reilly Media, 2016.\n"
    ]
   },
   {
@@ -43,13 +41,13 @@
    "id": "cceabe36",
    "metadata": {},
    "source": [
-    "If you are interested in physical modeling and complex systems, you might like:\n",
+    "Если вас интересует физическое моделирование и сложные системы, вам могут понравиться:\n",
     "\n",
     "* *Modeling and Simulation in Python: An Introduction for Scientists and Engineers*, No Starch Press, 2023.\n",
     "\n",
     "* *Think Complexity: Complexity Science and Computational Modeling*, O'Reilly Media, 2018.\n",
     "\n",
-    "These use NumPy, SciPy, pandas, and other Python libraries for data science and scientific computing."
+    "В этих книгах используются библиотеки NumPy, SciPy, pandas и другие инструменты Python для науки о данных и научных вычислений.\n"
    ]
   },
   {
@@ -57,13 +55,13 @@
    "id": "54a39121",
    "metadata": {},
    "source": [
-    "This book tries to find a balance between general principles of programming and details of Python.\n",
-    "As a result, it does not include every feature of the Python language.\n",
-    "For more about Python, and good advice about how to use it, I recommend *Fluent Python: Clear, Concise, and Effective Programming*, second edition by Luciano Ramalho, O'Reilly Media, 2022.\n",
+    "Эта книга пытается найти баланс между общими принципами программирования и деталями Python.\n",
+    "В результате она не включает каждую особенность языка.\n",
+    "Чтобы узнать больше о Python и получить хорошие советы по его использованию, рекомендую *Fluent Python: Clear, Concise, and Effective Programming*, второе издание, Luciano Ramalho, O'Reilly Media, 2022.\n",
     "\n",
-    "After an introduction to programming, a common next step is to learn about data structures and algorithms.\n",
-    "I have a work in progress on this topic, called *Data Structures and Information Retrieval in Python*.\n",
-    "A free electronic version is available from Green Tea Press at <https://greenteapress.com>."
+    "После введения в программирование обычный следующий шаг — изучение структур данных и алгоритмов.\n",
+    "У меня есть рабочий черновик на эту тему под названием *Data Structures and Information Retrieval in Python*.\n",
+    "Бесплатную электронную версию можно получить на Green Tea Press по адресу <https://greenteapress.com>.\n"
    ]
   },
   {
@@ -71,11 +69,11 @@
    "id": "a1598510",
    "metadata": {},
    "source": [
-    "As you work on more complex programs, you will encounter new challenges.\n",
-    "You might find it helpful to review the sections in this book about debugging.\n",
-    "In particular, remember the Six R's of debugging from [Chapter 12](section_debugging_12): reading, running, ruminating, rubber-ducking, retreating, and resting.\n",
+    "Работая над более сложными программами, вы столкнётесь с новыми трудностями.\n",
+    "Возможно, будет полезно освежить в памяти разделы этой книги о поиске и исправлении ошибок.\n",
+    "В частности, вспомните шесть 'R' отладки из [главы 12](section_debugging_12): чтение, запуск, размышление, резиновая уточка, отступление и отдых.\n",
     "\n",
-    "This book suggests tools to help with debugging, including the `print` and `repr` functions, the `structshape` function in [Chapter 11](section_debugging_11) -- and the built-in functions `isinstance`, `hasattr`, and `vars` in [Chapter 14](section_debugging_14)."
+    "В этой книге предлагаются инструменты для отладки, включая функции `print` и `repr`, функцию `structshape` в [главе 11](section_debugging_11) и встроенные функции `isinstance`, `hasattr` и `vars` из [главы 14](section_debugging_14).\n"
    ]
   },
   {
@@ -83,12 +81,12 @@
    "id": "fb4dd345",
    "metadata": {},
    "source": [
-    "It also suggests tools for testing programs, including the `assert` statement, the `doctest` module, and the `unittest` module.\n",
-    "Including tests in your programs is one of the best ways to prevent and detect errors, and save time debugging.\n",
+    "Книга также предлагает инструменты для тестирования программ, включая оператор `assert`, модуль `doctest` и модуль `unittest`.\n",
+    "Включение тестов в программы — один из лучших способов предотвращать и обнаруживать ошибки, экономя время на отладке.\n",
     "\n",
-    "But the best kind of debugging is the kind you don't have to do.\n",
-    "If you use an incremental development process as described in [Chapter 6](section_incremental) -- and test as you go -- you will make fewer errors and find them more quickly when you do.\n",
-    "Also, remember encapsulation and generalization from [Chapter 4](section_encapsulation), which is particularly useful when you are developing code in Jupyter notebooks."
+    "Но лучший вид отладки — тот, который вам не приходится делать.\n",
+    "Если вы будете использовать инкрементальный подход к разработке, описанный в [главе 6](section_incremental), и тестировать код по ходу дела, то допустите меньше ошибок и быстрее найдёте те, что всё же появятся.\n",
+    "Также помните об инкапсуляции и обобщении из [главы 4](section_encapsulation), что особенно полезно при разработке кода в Jupyter-ноутбуках.\n"
    ]
   },
   {
@@ -96,16 +94,15 @@
    "id": "0d29933e",
    "metadata": {},
    "source": [
-    "Throughout this book, I've suggested ways to use virtual assistants to help you learn, program, and debug.\n",
-    "I hope you are finding these tools useful.\n",
+    "На протяжении всей книги я предлагал способы использовать виртуальных ассистентов, чтобы учиться, программировать и отлаживать код.\n",
+    "Надеюсь, эти инструменты оказываются вам полезными.\n",
     "\n",
-    "In additional to virtual assistants like ChatGPT, you might also want to use a tool like Copilot that autocompletes code as you type.\n",
-    "I did not recommend using these tools, initially, because they can be overwhelming for beginners.\n",
-    "But you might want to explore them now.\n",
+    "В дополнение к виртуальным ассистентам вроде ChatGPT вы можете попробовать инструмент типа Copilot, который дописывает код по мере набора.\n",
+    "Изначально я не рекомендовал эти инструменты, потому что они могут быть слишком сложными для начинающих, но сейчас вы можете их попробовать.\n",
     "\n",
-    "Using AI tools effectively requires some experimentation and reflection to find a flow that works for you.\n",
-    "If you think it's a nuisance to copy code from ChatGPT to Jupyter, you might prefer something like Copilot.\n",
-    "But the cognitive work you do to compose a prompt and interpret the response can be as valuable as the code the tool generates, in the same vein as rubber duck debugging."
+    "Эффективное использование ИИ-тулов требует экспериментирования и размышлений, чтобы найти рабочий процесс, который подойдёт именно вам.\n",
+    "Если вам кажется неудобным копировать код из ChatGPT в Jupyter, возможно, вам больше понравится Copilot.\n",
+    "Но умственная работа по составлению запросов и интерпретации ответов может быть так же ценна, как и сгенерированный код — по аналогии с отладкой при помощи резиновой уточки.\n"
    ]
   },
   {
@@ -113,17 +110,17 @@
    "id": "c28d6815",
    "metadata": {},
    "source": [
-    "As you gain programming experience, you might want to explore other development environments.\n",
-    "I think Jupyter notebooks are a good place to start, but they are relatively new and not as widely-used as conventional integrated development environments (IDE).\n",
-    "For Python, the most popular IDEs include PyCharm and Spyder -- and Thonny, which is often recommended for beginners.\n",
-    "Other IDEs, like Visual Studio Code and Eclipse, work with other programming languages as well.\n",
-    "Or, as a simpler alternative, you can write Python programs using any text editor you like.\n",
+    "Набираясь опыта, вы можете захотеть освоить другие среды разработки.\n",
+    "Я считаю, что Jupyter — хорошее место для старта, но это сравнительно новая среда и она не столь широко распространена, как традиционные интегрированные среды разработки (IDE).\n",
+    "Для Python наиболее популярны PyCharm и Spyder — а также Thonny, который часто рекомендуют новичкам.\n",
+    "Другие IDE, такие как Visual Studio Code и Eclipse, работают и с другими языками программирования.\n",
+    "Более простой вариант — писать программы на Python в любом текстовом редакторе.\n",
     "\n",
-    "As you continue your programming journey, you don't have to go alone!\n",
-    "If you live in or near a city, there's a good chance there is a Python user group you can join.\n",
-    "These groups are usually friendly to beginners, so don't be afraid.\n",
-    "If there is no group near you, you might be able to join events remotely.\n",
-    "Also, keep an eye out for regional Python conferences."
+    "Продолжая свой путь в программировании, вам не обязательно идти в одиночку!\n",
+    "Если вы живёте в городе или рядом, вероятно, есть местная группа пользователей Python, к которой можно присоединиться.\n",
+    "Эти группы обычно дружелюбны к новичкам, так что не бойтесь.\n",
+    "Если поблизости нет такой группы, возможно, вы сможете участвовать в мероприятиях удалённо.\n",
+    "Также следите за региональными конференциями по Python.\n"
    ]
   },
   {
@@ -131,12 +128,12 @@
    "id": "28cb22bf",
    "metadata": {},
    "source": [
-    "One of the best ways to improve your programming skills is to learn another language.\n",
-    "If you are interested in statistics and data science, you might want to learn R.\n",
-    "But I particularly recommend learning a functional language like Racket or Elixir.\n",
-    "Functional programming requires a different kind of thinking, which changes the way you think about programs.\n",
+    "Один из лучших способов улучшить свои навыки программирования — выучить другой язык.\n",
+    "Если вас интересует статистика и Data Science, можно изучить R.\n",
+    "Но особенно рекомендую функциональный язык вроде Racket или Elixir.\n",
+    "Функциональное программирование требует иного подхода к мышлению, что меняет ваше представление о программах.\n",
     "\n",
-    "Good luck!"
+    "Удачи!\n"
    ]
   },
   {
@@ -160,7 +157,7 @@
     "\n",
     "Code license: [MIT License](https://mit-license.org/)\n",
     "\n",
-    "Text license: [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-nc-sa/4.0/)"
+    "Text license: [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-nc-sa/4.0/)\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- переведены на русский все Markdown-ячейки в `chapters/chap19.ipynb`

## Testing
- `python -m py_compile thinkpython.py`
- `python -m py_compile structshape.py diagram.py`
- `python -m py_compile Turtle.py` (warning expected)
- `python - <<'PY' ... validate nbformat ...`
